### PR TITLE
Fix start of advanced_streamer from within tcpserver-raspberry_pi

### DIFF
--- a/tcp_server/advanced_streamer.py
+++ b/tcp_server/advanced_streamer.py
@@ -43,10 +43,14 @@ def video():
         event_genertor(Video()),
         mimetype='multipart/x-mixed-replace; boundary=frame')
 
-
-if __name__ == '__main__':
+def main():
+    global app
     app.debug = True
     host = "0.0.0.0"
     port = 5000
     server = WSGIServer((host, port), app)
     server.serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/tcp_server/rpi_gpio_server.py
+++ b/tcp_server/rpi_gpio_server.py
@@ -126,7 +126,7 @@ def main():
             default=9788, help='host port number (int)')
     args = parser.parse_args()
     HOST, PORT = args.host, args.port
-    p = subprocess.Popen("python ./advanced_streamer.py 1", shell=True)
+    p = subprocess.Popen("python -c 'import advanced_streamer; advanced_streamer.main()'", shell=True)
     server = socketserver.TCPServer((HOST, PORT), TCP)
     # interrupt with Ctrl+c
     server.serve_forever()

--- a/tcp_server/setup.py
+++ b/tcp_server/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 # Setup
 setup(name="tcpserver-raspberry_pi",
       version="0.1.0",
-      py_modules = ['rpi_gpio_server'],
+      py_modules = ['rpi_gpio_server', 'advanced_streamer'],
       entry_points={
           'console_scripts': ['tcpserver-raspberry_pi = rpi_gpio_server:main']},
       zip_safe=False,


### PR DESCRIPTION
I found problems with starting the `tcpserver-raspberry_pi` after installing the package.
I think these are due to a hardcoded path `./advanced_streamer.py`. I have workaround this by executing the `advanced_streamer.main` function.